### PR TITLE
Update types and fix issue with flatten

### DIFF
--- a/__tests__/unit/check/__snapshots__/flatten.js.snap
+++ b/__tests__/unit/check/__snapshots__/flatten.js.snap
@@ -154,6 +154,86 @@ Object {
 }
 `;
 
+exports[`check.flatten should return multiple bundles with similar extensions 1`] = `
+Object {
+  "links": Object {
+    "http://foo": Object {
+      "bundles": Array [
+        Object {
+          "changed": 2,
+          "files": Array [
+            Object {
+              "fileName": "file1.shp",
+              "fileTypes": Array [
+                Object {
+                  "ext": "shp",
+                },
+              ],
+              "type": "file",
+              "url": "http://foo/file1.shp",
+            },
+            Object {
+              "fileName": "file1.dbf",
+              "fileTypes": Array [
+                Object {
+                  "ext": "dbf",
+                },
+              ],
+              "type": "file",
+              "url": "http://foo/file1.dbf",
+            },
+          ],
+          "type": "shp",
+        },
+      ],
+      "errors": Array [],
+      "urls": Array [
+        "http://foo/file1.shp",
+        "http://foo/file1.dbf",
+        "http://foo/file2.dbf",
+      ],
+      "warnings": Array [],
+    },
+    "http://foo/file1.dbf": Object {
+      "bundles": Array [],
+      "errors": Array [],
+      "urls": Array [],
+      "warnings": Array [],
+    },
+    "http://foo/file1.shp": Object {
+      "bundles": Array [],
+      "errors": Array [],
+      "urls": Array [],
+      "warnings": Array [],
+    },
+    "http://foo/file2.dbf": Object {
+      "bundles": Array [
+        Object {
+          "changed": 1,
+          "files": Array [
+            Object {
+              "fileName": "file2.dbf",
+              "fileTypes": Array [
+                Object {
+                  "ext": "dbf",
+                },
+              ],
+              "type": "file",
+              "url": "http://foo/file2.dbf",
+            },
+          ],
+          "type": "dbf",
+        },
+      ],
+      "errors": Array [],
+      "urls": Array [],
+      "warnings": Array [],
+    },
+  },
+  "temporaries": Array [],
+}
+`;
+
 exports[`check.flatten should return the file for a simple document 1`] = `
 Object {
   "links": Object {

--- a/__tests__/unit/check/__snapshots__/flatten.js.snap
+++ b/__tests__/unit/check/__snapshots__/flatten.js.snap
@@ -56,6 +56,65 @@ Object {
 }
 `;
 
+exports[`check.flatten should not consider related files as main when they also have the main type 1`] = `
+Object {
+  "links": Object {
+    "http://foo": Object {
+      "bundles": Array [
+        Object {
+          "changed": 2,
+          "files": Array [
+            Object {
+              "fileName": "file.tiff",
+              "fileTypes": Array [
+                Object {
+                  "ext": "tiff",
+                },
+              ],
+              "type": "file",
+              "url": "http://foo/file.tiff",
+            },
+            Object {
+              "fileName": "file.ovr",
+              "fileTypes": Array [
+                Object {
+                  "ext": "ovr",
+                },
+                Object {
+                  "ext": "tiff",
+                },
+              ],
+              "type": "file",
+              "url": "http://foo/file.ovr",
+            },
+          ],
+          "type": "tiff",
+        },
+      ],
+      "errors": Array [],
+      "urls": Array [
+        "http://foo/file.tiff",
+        "http://foo/file.ovr",
+      ],
+      "warnings": Array [],
+    },
+    "http://foo/file.ovr": Object {
+      "bundles": Array [],
+      "errors": Array [],
+      "urls": Array [],
+      "warnings": Array [],
+    },
+    "http://foo/file.tiff": Object {
+      "bundles": Array [],
+      "errors": Array [],
+      "urls": Array [],
+      "warnings": Array [],
+    },
+  },
+  "temporaries": Array [],
+}
+`;
+
 exports[`check.flatten should return a sole shapefile in an index-of 1`] = `
 Object {
   "links": Object {

--- a/__tests__/unit/check/flatten.js
+++ b/__tests__/unit/check/flatten.js
@@ -73,4 +73,33 @@ describe('check.flatten', () => {
 
     expect(res).toMatchSnapshot()
   })
+
+  it('should return multiple bundles with similar extensions', () => {
+    const res = flatten({
+      url: 'http://foo',
+      type: 'index-of',
+      children: [
+        {
+          url: 'http://foo/file1.shp',
+          type: 'file',
+          fileName: 'file1.shp',
+          fileTypes: [{ext: 'shp'}]
+        },
+        {
+          url: 'http://foo/file1.dbf',
+          type: 'file',
+          fileName: 'file1.dbf',
+          fileTypes: [{ext: 'dbf'}]
+        },
+        {
+          url: 'http://foo/file2.dbf',
+          type: 'file',
+          fileName: 'file2.dbf',
+          fileTypes: [{ext: 'dbf'}]
+        }
+      ]
+    })
+
+    expect(res).toMatchSnapshot()
+  })
 })

--- a/__tests__/unit/check/flatten.js
+++ b/__tests__/unit/check/flatten.js
@@ -50,4 +50,27 @@ describe('check.flatten', () => {
 
     expect(res).toMatchSnapshot()
   })
+
+  it('should not consider related files as main when they also have the main type', () => {
+    const res = flatten({
+      url: 'http://foo',
+      type: 'index-of',
+      children: [
+        {
+          url: 'http://foo/file.tiff',
+          type: 'file',
+          fileName: 'file.tiff',
+          fileTypes: [{ext: 'tiff'}]
+        },
+        {
+          url: 'http://foo/file.ovr',
+          type: 'file',
+          fileName: 'file.ovr',
+          fileTypes: [{ext: 'ovr'}, {ext: 'tiff'}]
+        }
+      ]
+    })
+
+    expect(res).toMatchSnapshot()
+  })
 })

--- a/jobs/check/flatten.js
+++ b/jobs/check/flatten.js
@@ -12,14 +12,29 @@ function getRelated(tokens, token, type) {
   })
 }
 
+function isMainType(file, type) {
+  const matches = type.extensions.some(
+    ext => file.fileTypes.some(ft => ft.ext && ft.ext.toLowerCase() === ext)
+  )
+
+  if (matches && type.related) {
+    // If the type has related files and the file also matches one of the related extensions,
+    // it does not qualify as the main type of the bundle.
+
+    return !type.related.some(
+      rel => file.fileTypes.some(ft => ft.ext && ft.ext.toLowerCase() === rel)
+    )
+  }
+
+  return matches
+}
+
 function matchPatterns(files, fileTypes) {
   const bundles = []
   const rest = [...files]
 
   fileTypes.forEach(type => {
-    const matchingNodes = rest.filter(file => type.extensions.some(ext =>
-      file.fileTypes.some(type => type.ext && type.ext.toLowerCase() === ext.toLowerCase())
-    ))
+    const matchingNodes = rest.filter(file => isMainType(file, type))
 
     matchingNodes.forEach(node => {
       const bundle = {

--- a/jobs/check/flatten.js
+++ b/jobs/check/flatten.js
@@ -1,9 +1,7 @@
-const {readFileSync} = require('fs')
-const {extname, join} = require('path')
+const {extname} = require('path')
 const {remove} = require('lodash')
-const {safeLoad} = require('js-yaml')
 
-const fileTypes = safeLoad(readFileSync(join(__dirname, '../../types.yml')))
+const fileTypes = require('../../lib/types')
 
 function getRelated(tokens, token, type) {
   return tokens.filter(t => {

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,11 @@
+const {readFileSync} = require('fs')
+const {join} = require('path')
+const {safeLoad} = require('js-yaml')
+
+const types = safeLoad(
+  readFileSync(
+    join(__dirname, '../types.yml')
+  )
+)
+
+module.exports = types

--- a/types.yml
+++ b/types.yml
@@ -3,7 +3,7 @@
 ##
 ## Always ensure that the extensions (and related) are properly lowercased.
 
-- name: geopkg
+- name: gpkg
   extensions:
     - gpkg
 

--- a/types.yml
+++ b/types.yml
@@ -1,3 +1,8 @@
+## The order of the types in this file is important.
+## This file exposes an array that defines the order in which the types will be matched.
+##
+## Always ensure that the extensions (and related) are properly lowercased.
+
 - name: geopkg
   extensions:
     - gpkg
@@ -42,6 +47,28 @@
     - id
     - ind
 
+- name: csv
+  extensions:
+    - csv
+    - tsv
+
+- name: tiff
+  extensions:
+    - tiff
+    - tif
+  related:
+    - tfw
+    - ovr
+    - xml
+
+- name: ecw
+  extensions:
+    - ecw
+
+- name: jpeg2000
+  extensions:
+    - jp2
+
 - name: document
   extensions:
     - pdf
@@ -51,14 +78,3 @@
     - xlsx
     - rtf
     - txt
-
-- name: csv
-  extensions:
-    - csv
-    - tsv
-
-# - name: image
-#   extensions:
-#     - ecw
-#     - tiff
-#     - jp2


### PR DESCRIPTION
Make sure that related types don’t get considered as main types.

For example, `ovr` files have a `tiff` magic, so they would be considered as `tiff` files on their own.