### PR TITLE
Disable caching for newly supported and analyzed types

### DIFF
--- a/jobs/check/check.js
+++ b/jobs/check/check.js
@@ -1,6 +1,7 @@
 const differenceInSeconds = require('date-fns/difference_in_seconds')
 const cacheControl = require('@tusbar/cache-control')
 
+const types = require('../../lib/types')
 const mongo = require('../../lib/utils/mongo')
 
 const {isBlacklisted} = require('./utils/blacklist')
@@ -34,10 +35,14 @@ async function createCheck(link, location, options) {
   if (isBlacklisted(location)) {
     check.state = 'blacklisted'
   } else if (link.cacheControl) {
-    const cc = cacheControl.parse(link.cacheControl)
+    const supportChanged = !link.supported && types.isSupported(link.fileTypes)
 
-    if (differenceInSeconds(lastCheck.createdAt, now) < cc.maxAge) {
-      check.state = 'skipped'
+    if (!supportChanged) {
+      const cc = cacheControl.parse(link.cacheControl)
+
+      if (differenceInSeconds(lastCheck.createdAt, now) < cc.maxAge) {
+        check.state = 'skipped'
+      }
     }
   }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,5 +1,6 @@
 const {readFileSync} = require('fs')
 const {join} = require('path')
+const {flatMap} = require('lodash')
 const {safeLoad} = require('js-yaml')
 
 const types = safeLoad(
@@ -8,4 +9,16 @@ const types = safeLoad(
   )
 )
 
+const extensions = new Set(
+  flatMap(types, ({extensions, related}) => ([
+    ...extensions,
+    ...(related || [])
+  ]))
+)
+
+function isSupported(fileTypes = []) {
+  return fileTypes.some(ft => ft.ext && extensions.has(ft.ext.toLowerCase()))
+}
+
 module.exports = types
+module.exports.isSupported = isSupported


### PR DESCRIPTION
This allows to re-analyze files whenever type support changes.

Before this, if support was added for a type we would have had to manually remove all the cache for the matching files.

---

I’m not sure that this is the right approach. The same logic gets duplicated in multiple places and it forces us to store the fileTypes for links. But it handles most cases.

What do you think @jdesboeufs?