### PR TITLE
Allow analyzing already ignored files & fix checks creation

### DIFF
--- a/__test-helpers__/snapshots.js
+++ b/__test-helpers__/snapshots.js
@@ -1,0 +1,23 @@
+function downloadsSnapshot(downloads) {
+  return downloads.map(({name, type, archive, path, files}) => {
+    return {
+      name,
+      type,
+      archive,
+      path,
+      files
+    }
+  }).sort((a, b) => {
+    if (a.name < b.name) {
+      return -1
+    }
+
+    if (a.name > b.name) {
+      return 1
+    }
+
+    return 0
+  })
+}
+
+module.exports = {downloadsSnapshot}

--- a/__tests__/integration/__snapshots__/index-of.js.snap
+++ b/__tests__/integration/__snapshots__/index-of.js.snap
@@ -26,6 +26,8 @@ Array [
         "size": 3,
       },
     ],
+    "name": "cool.shp",
+    "path": "cool.shp",
     "type": "shp",
   },
 ]
@@ -33,37 +35,6 @@ Array [
 
 exports[`test-link-proxy-index-of should find a shapefile within the zip file of the index-of 1`] = `
 Array [
-  Object {
-    "archive": true,
-    "files": Array [
-      Object {
-        "digest": "sha384-+1t5TeJcJ5X34OTBKFd9lDXmWfSP4yyKwNCd6HqLGKChrQodibskoUMz8lbBRABG",
-        "name": "house.shp",
-        "size": 11,
-      },
-      Object {
-        "digest": "sha384-g/OOiDmdzWdrQElweiK218tYBpzU+Sqpg39YDz/OGKo2bHgTMSfs8PTUFsXaKRtU",
-        "name": "house.cpg",
-        "size": 11,
-      },
-      Object {
-        "digest": "sha384-N0PxnfQbUbtgRHdg85YR5d23TJyCCw9dkMQ2b7sKrMLplKm2yiK2a+bPBWapI+PA",
-        "name": "house.dbf",
-        "size": 11,
-      },
-      Object {
-        "digest": "sha384-KjIjW8mDGhYle3IvWHrtMZ3Yng0z3375s8hE8w9gcirOr8Ha1mldECb4q04fg4vc",
-        "name": "house.prj",
-        "size": 11,
-      },
-      Object {
-        "digest": "sha384-FA1fzHfLn30z4w1QOE8IM3GlS45Xvmodk+MQdzWCkx8ceyOzE3aLBV9Gl7XXZJ4e",
-        "name": "house.shx",
-        "size": 11,
-      },
-    ],
-    "type": "shp",
-  },
   Object {
     "archive": true,
     "files": Array [
@@ -93,6 +64,41 @@ Array [
         "size": 11,
       },
     ],
+    "name": "hotel.shp",
+    "path": "hotel.zip/hotel.shp",
+    "type": "shp",
+  },
+  Object {
+    "archive": true,
+    "files": Array [
+      Object {
+        "digest": "sha384-+1t5TeJcJ5X34OTBKFd9lDXmWfSP4yyKwNCd6HqLGKChrQodibskoUMz8lbBRABG",
+        "name": "house.shp",
+        "size": 11,
+      },
+      Object {
+        "digest": "sha384-g/OOiDmdzWdrQElweiK218tYBpzU+Sqpg39YDz/OGKo2bHgTMSfs8PTUFsXaKRtU",
+        "name": "house.cpg",
+        "size": 11,
+      },
+      Object {
+        "digest": "sha384-N0PxnfQbUbtgRHdg85YR5d23TJyCCw9dkMQ2b7sKrMLplKm2yiK2a+bPBWapI+PA",
+        "name": "house.dbf",
+        "size": 11,
+      },
+      Object {
+        "digest": "sha384-KjIjW8mDGhYle3IvWHrtMZ3Yng0z3375s8hE8w9gcirOr8Ha1mldECb4q04fg4vc",
+        "name": "house.prj",
+        "size": 11,
+      },
+      Object {
+        "digest": "sha384-FA1fzHfLn30z4w1QOE8IM3GlS45Xvmodk+MQdzWCkx8ceyOzE3aLBV9Gl7XXZJ4e",
+        "name": "house.shx",
+        "size": 11,
+      },
+    ],
+    "name": "house.shp",
+    "path": "house.zip/house.shp",
     "type": "shp",
   },
 ]
@@ -129,6 +135,8 @@ Array [
         "size": 11,
       },
     ],
+    "name": "data1.shp",
+    "path": "data1.zip/data1.shp",
     "type": "shp",
   },
   Object {
@@ -160,6 +168,8 @@ Array [
         "size": 11,
       },
     ],
+    "name": "data2.shp",
+    "path": "data2.zip/data2.shp",
     "type": "shp",
   },
 ]

--- a/__tests__/integration/__snapshots__/zip-shp.js.snap
+++ b/__tests__/integration/__snapshots__/zip-shp.js.snap
@@ -31,6 +31,8 @@ Array [
         "size": 11,
       },
     ],
+    "name": "data.shp",
+    "path": "data.zip/data.shp",
     "type": "shp",
   },
 ]

--- a/__tests__/integration/index-of.js
+++ b/__tests__/integration/index-of.js
@@ -7,6 +7,7 @@ const check = require('../../jobs/check')
 
 const indexOf = require('../../__test-helpers__/index-of')
 const {shapefile} = require('../../__test-helpers__/archive')
+const {downloadsSnapshot} = require('../../__test-helpers__/snapshots')
 
 const NAME = 'test-link-proxy-index-of'
 
@@ -45,11 +46,7 @@ describe(NAME, () => {
     await check(_id, URL)
 
     const summary = await getLinkSummary(_id)
-    expect(summary.downloads.map(({type, archive, files}) => ({
-      type,
-      archive,
-      files
-    }))).toMatchSnapshot()
+    expect(downloadsSnapshot(summary.downloads)).toMatchSnapshot()
   })
 
   it('should find a shapefile within the zip file of the index-of of the index-of', async () => {
@@ -78,11 +75,7 @@ describe(NAME, () => {
     await check(_id, URL)
 
     const summary = await getLinkSummary(_id)
-    expect(summary.downloads.map(({type, archive, files}) => ({
-      type,
-      archive,
-      files
-    }))).toMatchSnapshot()
+    expect(downloadsSnapshot(summary.downloads)).toMatchSnapshot()
   })
 
   it('should find a shapefile listed in the index-of', async () => {
@@ -103,10 +96,6 @@ describe(NAME, () => {
     await check(_id, URL)
 
     const summary = await getLinkSummary(_id)
-    expect(summary.downloads.map(({type, archive, files}) => ({
-      type,
-      archive,
-      files
-    }))).toMatchSnapshot()
+    expect(downloadsSnapshot(summary.downloads)).toMatchSnapshot()
   })
 })

--- a/__tests__/integration/zip-shp.js
+++ b/__tests__/integration/zip-shp.js
@@ -6,6 +6,7 @@ const {upsertLink, getLinkSummary} = require('../../lib/link')
 const check = require('../../jobs/check')
 
 const {shapefile} = require('../../__test-helpers__/archive')
+const {downloadsSnapshot} = require('../../__test-helpers__/snapshots')
 
 const NAME = 'test-link-proxy-zip-shp'
 
@@ -37,10 +38,6 @@ describe(NAME, () => {
     await check(_id, url)
 
     const summary = await getLinkSummary(_id)
-    expect(summary.downloads.map(({type, archive, files}) => ({
-      type,
-      archive,
-      files
-    }))).toMatchSnapshot()
+    expect(downloadsSnapshot(summary.downloads)).toMatchSnapshot()
   })
 })

--- a/__tests__/unit/check/__snapshots__/check.js.snap
+++ b/__tests__/unit/check/__snapshots__/check.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`check.check should create a check for a given location and link 1`] = `
+Object {
+  "_id": Any<ObjectID>,
+  "createdAt": Any<Date>,
+  "linkId": Any<ObjectID>,
+  "location": "http://example.org/1",
+  "number": 1,
+  "options": undefined,
+  "state": "started",
+  "updatedAt": Any<Date>,
+}
+`;

--- a/__tests__/unit/check/__snapshots__/flatten.js.snap
+++ b/__tests__/unit/check/__snapshots__/flatten.js.snap
@@ -2,6 +2,7 @@
 
 exports[`check.flatten should flatten a shapefile in an index-of 1`] = `
 Object {
+  "ignored": Array [],
   "links": Object {
     "http://foo": Object {
       "bundles": Array [
@@ -53,11 +54,13 @@ Object {
     },
   },
   "temporaries": Array [],
+  "typesVersion": 1,
 }
 `;
 
 exports[`check.flatten should not consider related files as main when they also have the main type 1`] = `
 Object {
+  "ignored": Array [],
   "links": Object {
     "http://foo": Object {
       "bundles": Array [
@@ -112,11 +115,13 @@ Object {
     },
   },
   "temporaries": Array [],
+  "typesVersion": 1,
 }
 `;
 
 exports[`check.flatten should return a sole shapefile in an index-of 1`] = `
 Object {
+  "ignored": Array [],
   "links": Object {
     "http://foo": Object {
       "bundles": Array [],
@@ -151,11 +156,13 @@ Object {
     },
   },
   "temporaries": Array [],
+  "typesVersion": 1,
 }
 `;
 
 exports[`check.flatten should return multiple bundles with similar extensions 1`] = `
 Object {
+  "ignored": Array [],
   "links": Object {
     "http://foo": Object {
       "bundles": Array [
@@ -231,11 +238,13 @@ Object {
     },
   },
   "temporaries": Array [],
+  "typesVersion": 1,
 }
 `;
 
 exports[`check.flatten should return the file for a simple document 1`] = `
 Object {
+  "ignored": Array [],
   "links": Object {
     "http://foo": Object {
       "bundles": Array [
@@ -261,5 +270,32 @@ Object {
     },
   },
   "temporaries": Array [],
+  "typesVersion": 1,
+}
+`;
+
+exports[`check.flatten should support ignored files types 1`] = `
+Object {
+  "ignored": Array [
+    Object {
+      "fileTypes": Array [
+        Object {
+          "ext": "unknown stuff",
+        },
+      ],
+      "type": "file",
+      "url": "http://foo",
+    },
+  ],
+  "links": Object {
+    "http://foo": Object {
+      "bundles": Array [],
+      "errors": Array [],
+      "urls": Array [],
+      "warnings": Array [],
+    },
+  },
+  "temporaries": Array [],
+  "typesVersion": 1,
 }
 `;

--- a/__tests__/unit/check/__snapshots__/flatten.js.snap
+++ b/__tests__/unit/check/__snapshots__/flatten.js.snap
@@ -54,7 +54,6 @@ Object {
     },
   },
   "temporaries": Array [],
-  "typesVersion": 1,
 }
 `;
 
@@ -115,7 +114,6 @@ Object {
     },
   },
   "temporaries": Array [],
-  "typesVersion": 1,
 }
 `;
 
@@ -156,7 +154,6 @@ Object {
     },
   },
   "temporaries": Array [],
-  "typesVersion": 1,
 }
 `;
 
@@ -238,7 +235,6 @@ Object {
     },
   },
   "temporaries": Array [],
-  "typesVersion": 1,
 }
 `;
 
@@ -270,7 +266,6 @@ Object {
     },
   },
   "temporaries": Array [],
-  "typesVersion": 1,
 }
 `;
 
@@ -296,6 +291,5 @@ Object {
     },
   },
   "temporaries": Array [],
-  "typesVersion": 1,
 }
 `;

--- a/__tests__/unit/check/check.js
+++ b/__tests__/unit/check/check.js
@@ -127,4 +127,25 @@ describe('check.check', () => {
 
     expect(check.state).toBe('started')
   })
+
+  it('should skip immutable files', async () => {
+    const link = {
+      _id: new mongo.ObjectID(),
+      cacheControl: 'immutable'
+    }
+
+    await mongo.db.collection('checks').insertOne({
+      createdAt: new Date(),
+      linkId: link._id,
+      location: 'http://example.org/8'
+    })
+
+    await new Promise(resolve => {
+      setTimeout(() => resolve(), 2000)
+    })
+
+    const check = await createCheck(link, 'http://example.org/8', {})
+
+    expect(check.state).toBe('skipped')
+  })
 })

--- a/__tests__/unit/check/check.js
+++ b/__tests__/unit/check/check.js
@@ -1,0 +1,130 @@
+const {createCheck} = require('../../../jobs/check/check')
+const mongo = require('../../../lib/utils/mongo')
+const store = require('../../../lib/utils/store')
+
+const NAME = 'test-link-proxy-unit-check-check'
+
+describe('check.check', () => {
+  beforeAll(async () => {
+    process.env.MONGO_DB = NAME
+
+    await mongo.connect()
+    await mongo.ensureIndexes()
+  })
+
+  afterAll(async () => {
+    await mongo.db.dropDatabase()
+    await mongo.disconnect(true)
+  })
+
+  it('should create a check for a given location and link', async () => {
+    const link = {_id: new mongo.ObjectID()}
+
+    const check = await createCheck(link, 'http://example.org/1')
+
+    expect(check).toMatchSnapshot({
+      _id: expect.any(mongo.ObjectID),
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+      linkId: expect.any(mongo.ObjectID)
+    })
+  })
+
+  it('should increase the number when running multiple checks on the same link', async () => {
+    const link = {_id: new mongo.ObjectID()}
+
+    await createCheck(link, 'http://example.org/2')
+    const check = await createCheck(link, 'http://example.org/2')
+
+    expect(check.number).toBe(2)
+  })
+
+  it('should increase the number even if the last check doesn’t have one', async () => {
+    const link = {_id: new mongo.ObjectID()}
+
+    await mongo.db.collection('checks').insertOne({
+      linkId: link._id,
+      location: 'http://example.org/3'
+    })
+
+    const check = await createCheck(link, 'http://example.org/3')
+
+    expect(check.number).toBe(2)
+  })
+
+  it('should mark checks on blacklisted domains as blacklisted', async () => {
+    const link = {_id: new mongo.ObjectID()}
+
+    const check = await createCheck(link, store.client.endpoint.href)
+
+    expect(check.state).toBe('blacklisted')
+  })
+
+  it('should not skip the check if Cache-Control is available and there is no previous check', async () => {
+    const link = {
+      _id: new mongo.ObjectID(),
+      cacheControl: 'max-age=1234567890'
+    }
+
+    const check = await createCheck(link, 'http://example.org/4', {})
+
+    expect(check.state).toBe('started')
+  })
+
+  it('should skip the check if max-age hasn’t expired yet', async () => {
+    const link = {
+      _id: new mongo.ObjectID(),
+      cacheControl: 'max-age=1234567890'
+    }
+
+    await mongo.db.collection('checks').insertOne({
+      createdAt: new Date(),
+      linkId: link._id,
+      location: 'http://example.org/5'
+    })
+
+    const check = await createCheck(link, 'http://example.org/5', {})
+
+    expect(check.state).toBe('skipped')
+  })
+
+  it('should ignore Cache-Control checks if noCache is enabled', async () => {
+    const link = {
+      _id: new mongo.ObjectID(),
+      cacheControl: 'max-age=1234567890'
+    }
+
+    await mongo.db.collection('checks').insertOne({
+      createdAt: new Date(),
+      linkId: link._id,
+      location: 'http://example.org/6'
+    })
+
+    const check = await createCheck(link, 'http://example.org/6', {
+      noCache: true
+    })
+
+    expect(check.state).toBe('started')
+  })
+
+  it('should not skip the check if max-age has expired', async () => {
+    const link = {
+      _id: new mongo.ObjectID(),
+      cacheControl: 'max-age=1'
+    }
+
+    await mongo.db.collection('checks').insertOne({
+      createdAt: new Date(),
+      linkId: link._id,
+      location: 'http://example.org/7'
+    })
+
+    await new Promise(resolve => {
+      setTimeout(() => resolve(), 2000)
+    })
+
+    const check = await createCheck(link, 'http://example.org/7', {})
+
+    expect(check.state).toBe('started')
+  })
+})

--- a/__tests__/unit/check/flatten.js
+++ b/__tests__/unit/check/flatten.js
@@ -102,4 +102,14 @@ describe('check.flatten', () => {
 
     expect(res).toMatchSnapshot()
   })
+
+  it('should support ignored files types', () => {
+    const res = flatten({
+      url: 'http://foo',
+      type: 'file',
+      fileTypes: [{ext: 'unknown stuff'}]
+    })
+
+    expect(res).toMatchSnapshot()
+  })
 })

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -13,13 +13,14 @@
 # }
 
 MINIO_BUCKET=${MINIO_BUCKET:-link-proxy/link-proxy-files}
+MONGO_DB=${MONGO_DB:-link-proxy}
 
 guard() {
   $@ && echo "✨  Done" || echo "❌  Failed"
 }
 
 echo "1️⃣  Drop mongo database"
-guard docker run -it --rm mongo:latest mongo link-proxy --host docker.for.mac.host.internal --eval "db.dropDatabase()"
+guard docker run -it --rm mongo:latest mongo $MONGO_DB --host docker.for.mac.host.internal --eval "db.dropDatabase()"
 
 echo
 

--- a/jobs/check/cache.js
+++ b/jobs/check/cache.js
@@ -78,7 +78,7 @@ function setUrlCache(noCache) {
   }
 }
 
-function getFileCache(noCache) {
+function getFileCache() {
   return async token => {
     const link = await mongo.db.collection('links').findOne({
       locations: {
@@ -103,9 +103,7 @@ function getFileCache(noCache) {
     })
 
     if (cache) {
-      // Return true if caching is enabled, false if caching is disabled
-      // noCache === true means that caching is disabled.
-      return !noCache
+      return true
     }
 
     const now = new Date()

--- a/jobs/check/check.js
+++ b/jobs/check/check.js
@@ -36,7 +36,7 @@ async function createCheck(link, location, options) {
   } else if (lastCheck && link.cacheControl && !options.noCache) {
     const cc = cacheControl.parse(link.cacheControl)
 
-    if (differenceInSeconds(now, lastCheck.createdAt) < cc.maxAge) {
+    if (cc.immutable || differenceInSeconds(now, lastCheck.createdAt) < cc.maxAge) {
       check.state = 'skipped'
     }
   }

--- a/jobs/check/check.js
+++ b/jobs/check/check.js
@@ -33,7 +33,7 @@ async function createCheck(link, location, options) {
 
   if (isBlacklisted(location)) {
     check.state = 'blacklisted'
-  } else if (link.cacheControl) {
+  } else if (link.cacheControl && !options.noCache) {
     const cc = cacheControl.parse(link.cacheControl)
 
     if (differenceInSeconds(lastCheck.createdAt, now) < cc.maxAge) {

--- a/jobs/check/check.js
+++ b/jobs/check/check.js
@@ -23,7 +23,7 @@ async function createCheck(link, location, options) {
 
   const check = {
     linkId: link._id,
-    number: lastCheck ? (lastCheck.number || 0) + 1 : 1,
+    number: lastCheck ? (lastCheck.number || 1) + 1 : 1,
     createdAt: now,
     updatedAt: now,
     state: 'started',
@@ -33,10 +33,10 @@ async function createCheck(link, location, options) {
 
   if (isBlacklisted(location)) {
     check.state = 'blacklisted'
-  } else if (link.cacheControl && !options.noCache) {
+  } else if (lastCheck && link.cacheControl && !options.noCache) {
     const cc = cacheControl.parse(link.cacheControl)
 
-    if (differenceInSeconds(lastCheck.createdAt, now) < cc.maxAge) {
+    if (differenceInSeconds(now, lastCheck.createdAt) < cc.maxAge) {
       check.state = 'skipped'
     }
   }

--- a/jobs/check/flatten.js
+++ b/jobs/check/flatten.js
@@ -12,41 +12,50 @@ function getRelated(tokens, token, type) {
   })
 }
 
-function isMainType(file, type) {
-  const matches = type.extensions.some(
-    ext => file.fileTypes.some(ft => ft.ext && ft.ext.toLowerCase() === ext)
+function isMainType(node, type) {
+  const isMain = type.extensions.some(
+    ext => node.fileTypes.some(ft => ft.ext && ft.ext.toLowerCase() === ext)
   )
 
-  if (matches && type.related) {
-    // If the type has related files and the file also matches one of the related extensions,
-    // it does not qualify as the main type of the bundle.
+  if (isMain && type.related) {
+    // If the type has related files and the file also matches
+    // one of the related extensions, it does not qualify as the
+    // main type of the bundle.
 
     return !type.related.some(
-      rel => file.fileTypes.some(ft => ft.ext && ft.ext.toLowerCase() === rel)
+      rel => node.fileTypes.some(ft => ft.ext && ft.ext.toLowerCase() === rel)
     )
   }
 
-  return matches
+  return isMain
 }
 
-function matchPatterns(files, fileTypes) {
+function matchPatterns(nodes, types = fileTypes.types) {
   const bundles = []
-  const rest = [...files]
+  const ignored = [...nodes]
 
-  fileTypes.forEach(type => {
-    const matchingNodes = rest.filter(file => isMainType(file, type))
+  // It is important to loop over all types sequentially as the order
+  // defined in `types` is important.
+  for (const type of types) {
+    const matching = []
 
-    matchingNodes.forEach(node => {
+    for (const node of ignored) {
+      if (isMainType(node, type)) {
+        matching.push(node)
+      }
+    }
+
+    for (const node of matching) {
       const bundle = {
         type: type.name,
         files: [node],
         changed: node.unchanged ? 0 : 1
       }
 
-      remove(rest, node)
+      remove(ignored, node)
 
       if (type.related && type.related.length > 0) {
-        const related = getRelated(files, node, type)
+        const related = getRelated(ignored, node, type)
 
         bundle.files = bundle.files.concat(related)
 
@@ -55,15 +64,15 @@ function matchPatterns(files, fileTypes) {
             ++bundle.changed
           }
 
-          remove(rest, n)
+          remove(ignored, n)
         })
       }
 
       bundles.push(bundle)
-    })
-  })
+    }
+  }
 
-  return bundles
+  return {bundles, ignored}
 }
 
 function flattenNodes(result, nodes, parentNode) {
@@ -115,7 +124,8 @@ function flattenNodes(result, nodes, parentNode) {
     }
   }
 
-  for (const bundle of matchPatterns(files, fileTypes)) {
+  const {bundles, ignored} = matchPatterns(files)
+  for (const bundle of bundles) {
     const firstUrl = bundle.files[0].url
 
     if (bundle.files.length === 1 && firstUrl) {
@@ -128,11 +138,15 @@ function flattenNodes(result, nodes, parentNode) {
       parentLink.bundles.push(bundle)
     }
   }
+
+  result.ignored.push(...ignored)
 }
 
 function flatten(node) {
   const result = {
+    typesVersion: fileTypes.version,
     temporaries: [],
+    ignored: [],
     links: {}
   }
 

--- a/jobs/check/flatten.js
+++ b/jobs/check/flatten.js
@@ -144,7 +144,6 @@ function flattenNodes(result, nodes, parentNode) {
 
 function flatten(node) {
   const result = {
-    typesVersion: fileTypes.version,
     temporaries: [],
     ignored: [],
     links: {}

--- a/jobs/check/index.js
+++ b/jobs/check/index.js
@@ -108,7 +108,9 @@ async function analyze(linkId, location, options) {
       }
     }
 
-    await Bluebird.map(res.bundles, async bundle => {
+    const changedBundles = res.bundles.filter(bundle => bundle.changed > 0)
+
+    await Bluebird.map(changedBundles, async bundle => {
       const mainFile = bundle.files[0]
 
       const download = {
@@ -126,21 +128,18 @@ async function analyze(linkId, location, options) {
         }))
       }
 
-      let previous
-      if (bundle.changed !== bundle.files.length) {
-        previous = await mongo.db.collection('downloads').findOne({
-          linkId: subLink._id,
-          type: bundle.type,
-          name: mainFile.fileName
-        }, {
-          sort: {
-            createdAt: -1
-          },
-          projection: {
-            url: 1
-          }
-        })
-      }
+      const previous = await mongo.db.collection('downloads').findOne({
+        linkId: subLink._id,
+        type: bundle.type,
+        name: mainFile.fileName
+      }, {
+        sort: {
+          createdAt: -1
+        },
+        projection: {
+          url: 1
+        }
+      })
 
       if (previous) {
         changes.bundles.remove.push(previous._id)

--- a/jobs/check/index.js
+++ b/jobs/check/index.js
@@ -188,7 +188,15 @@ async function analyze(linkId, location, options) {
   await mongo.db.collection('checks').updateOne({_id: check._id}, {
     $set: {
       state: 'finished',
-      updatedAt: new Date()
+      updatedAt: new Date(),
+      ignored: result.ignored.map(token => ({
+        url: token.url || token.fromUrl,
+        digest: token.digest,
+        fileName: token.fileName,
+        fileSize: token.fileSize,
+        filePath: token.filePath,
+        fileTypes: token.fileTypes
+      }))
     }
   })
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -2,10 +2,10 @@ const {readFileSync} = require('fs')
 const {join} = require('path')
 const {safeLoad} = require('js-yaml')
 
-const types = safeLoad(
+const {types, version} = safeLoad(
   readFileSync(
     join(__dirname, '../types.yml')
   )
 )
 
-module.exports = types
+module.exports = {types, version}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,12 @@
     "globalSetup": "./jest.setup.js",
     "globalTeardown": "./jest.teardown.js",
     "collectCoverage": true,
+    "collectCoverageFrom": [
+      "index.js",
+      "worker.js",
+      "jobs/**/*.js",
+      "lib/**/*.js"
+    ],
     "coverageReporters": [
       "lcov",
       "text-summary"

--- a/types.yml
+++ b/types.yml
@@ -3,7 +3,7 @@
 ##
 ## Always ensure that the extensions (and related) are properly lowercased.
 
-version: 1
+version: '1'
 
 types:
   - name: gpkg

--- a/types.yml
+++ b/types.yml
@@ -3,78 +3,81 @@
 ##
 ## Always ensure that the extensions (and related) are properly lowercased.
 
-- name: gpkg
-  extensions:
-    - gpkg
+version: 1
 
-- name: shp
-  extensions:
-    - shp
-  related:
-    - shx
-    - dbf
-    - prj
-    - sbn
-    - sbx
-    - fbn
-    - fbx
-    - ain
-    - aih
-    - shp.xml
-    - atx
-    - qix
-    - cpg
-    - qpj
+types:
+  - name: gpkg
+    extensions:
+      - gpkg
 
-- name: dbf
-  extensions:
-    - dbf
-  related:
-    - cpg
+  - name: shp
+    extensions:
+      - shp
+    related:
+      - shx
+      - dbf
+      - prj
+      - sbn
+      - sbx
+      - fbn
+      - fbx
+      - ain
+      - aih
+      - shp.xml
+      - atx
+      - qix
+      - cpg
+      - qpj
 
-- name: mif
-  extensions:
-    - mif
-  related:
-    - mid
+  - name: dbf
+    extensions:
+      - dbf
+    related:
+      - cpg
 
-- name: tab
-  extensions:
-    - tab
-  related:
-    - dat
-    - map
-    - id
-    - ind
+  - name: mif
+    extensions:
+      - mif
+    related:
+      - mid
 
-- name: csv
-  extensions:
-    - csv
-    - tsv
+  - name: tab
+    extensions:
+      - tab
+    related:
+      - dat
+      - map
+      - id
+      - ind
 
-- name: tiff
-  extensions:
-    - tiff
-    - tif
-  related:
-    - tfw
-    - ovr
-    - xml
+  - name: csv
+    extensions:
+      - csv
+      - tsv
 
-- name: ecw
-  extensions:
-    - ecw
+  - name: tiff
+    extensions:
+      - tiff
+      - tif
+    related:
+      - tfw
+      - ovr
+      - xml
 
-- name: jpeg2000
-  extensions:
-    - jp2
+  - name: ecw
+    extensions:
+      - ecw
 
-- name: document
-  extensions:
-    - pdf
-    - doc
-    - docx
-    - xls
-    - xlsx
-    - rtf
-    - txt
+  - name: jpeg2000
+    extensions:
+      - jp2
+
+  - name: document
+    extensions:
+      - pdf
+      - doc
+      - docx
+      - xls
+      - xlsx
+      - rtf
+      - txt


### PR DESCRIPTION
- [x] Rewrite flatten/matchPatterns and support ignored files
- [x] Stop duplicating files cache with `noCache`
- [x] Invalidate cache when types are now supported
- [x] Re-analyze previously ignored files
- [x] Fix checks creation and add tests

Close #15 