### PR TITLE
Support errored checks

### DIFF
--- a/__tests__/integration/blacklist.js
+++ b/__tests__/integration/blacklist.js
@@ -25,7 +25,7 @@ describe(NAME, () => {
     const {_id} = await upsertLink(URL)
     await check(_id, URL)
 
-    const checks = await getLinkChecks(_id)
-    expect(checks[0].state).toEqual('blacklisted')
+    const [lastCheck] = await getLinkChecks(_id)
+    expect(lastCheck.state).toBe('blacklisted')
   })
 })

--- a/__tests__/integration/errored.js
+++ b/__tests__/integration/errored.js
@@ -1,0 +1,32 @@
+const nock = require('nock')
+
+const mongo = require('../../lib/utils/mongo')
+const {upsertLink} = require('../../lib/link')
+const check = require('../../jobs/check')
+
+const NAME = 'test-link-proxy-errored'
+
+beforeAll(async () => {
+  process.env.MONGO_DB = NAME
+
+  await mongo.connect()
+  await mongo.ensureIndexes()
+})
+
+afterAll(async () => {
+  await mongo.db.dropDatabase()
+  await mongo.disconnect(true)
+})
+
+describe(NAME, () => {
+  it('should do something own links', async () => {
+    const URL = `http://${NAME}-throw-http`
+
+    nock(URL).get('/error').reply(500, () => null)
+
+    const url = `${URL}/error`
+    const {_id} = await upsertLink(url)
+
+    await expect(check(_id, url)).rejects.toThrow('Received invalid status code: 500')
+  })
+})

--- a/__tests__/integration/errored.js
+++ b/__tests__/integration/errored.js
@@ -2,6 +2,7 @@ const nock = require('nock')
 
 const mongo = require('../../lib/utils/mongo')
 const {upsertLink} = require('../../lib/link')
+const {getLinkChecks} = require('../../lib/check')
 const check = require('../../jobs/check')
 
 const NAME = 'test-link-proxy-errored'
@@ -19,14 +20,29 @@ afterAll(async () => {
 })
 
 describe(NAME, () => {
-  it('should do something own links', async () => {
-    const URL = `http://${NAME}-throw-http`
+  it('should throw if the check returns a 500', async () => {
+    const URL = `http://${NAME}-error-500`
 
-    nock(URL).get('/error').reply(500, () => null)
+    nock(URL).get('/500').reply(500, () => null)
 
-    const url = `${URL}/error`
+    const url = `${URL}/500`
     const {_id} = await upsertLink(url)
 
     await expect(check(_id, url)).rejects.toThrow('Received invalid status code: 500')
+  })
+
+  it('should not throw if the check returns a 404', async () => {
+    const URL = `http://${NAME}-error-404`
+
+    nock(URL).get('/404').reply(404, () => null)
+
+    const url = `${URL}/404`
+    const {_id} = await upsertLink(url)
+
+    await check(_id, url)
+
+    const [lastCheck] = await getLinkChecks(_id)
+    expect(lastCheck.state).toBe('finished')
+    expect(lastCheck.statusCode).toBe(404)
   })
 })

--- a/index.js
+++ b/index.js
@@ -88,7 +88,6 @@ const routes = router(
     }, {
       jobId: link._id,
       removeOnComplete: true,
-      removeOnFail: true,
       timeout: ms('30m')
     })
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const micro = require('micro')
 const {get, post, router} = require('microrouter')
+const ms = require('ms')
 
 const sentry = require('./lib/utils/sentry')
 const mongo = require('./lib/utils/mongo')
@@ -87,7 +88,8 @@ const routes = router(
     }, {
       jobId: link._id,
       removeOnComplete: true,
-      timeout: 1000 * 60 * 30
+      removeOnFail: true,
+      timeout: ms('30m')
     })
 
     return link

--- a/jobs/check/check.js
+++ b/jobs/check/check.js
@@ -13,6 +13,7 @@ async function createCheck(link, location, options) {
   }, {
     projection: {
       createdAt: 1,
+      state: 1,
       number: 1,
       _id: 0
     },
@@ -20,6 +21,13 @@ async function createCheck(link, location, options) {
       number: -1
     }
   })
+
+  if (lastCheck && lastCheck.state === 'errored') {
+    options = {
+      ...options,
+      noCache: true
+    }
+  }
 
   const check = {
     linkId: link._id,

--- a/jobs/check/errors.js
+++ b/jobs/check/errors.js
@@ -1,0 +1,10 @@
+class PlungerError extends Error {
+  constructor(message) {
+    super(message)
+
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+module.exports = {PlungerError}

--- a/jobs/check/failed.js
+++ b/jobs/check/failed.js
@@ -1,0 +1,26 @@
+const mongo = require('../../lib/utils/mongo')
+
+async function onCheckFailed(linkId, err) {
+  const check = await mongo.db.collection('checks').findOne({
+    linkId: new mongo.ObjectID(linkId)
+  }, {
+    projection: {
+      _id: 1,
+      options: 1
+    },
+    sort: {
+      number: -1
+    }
+  })
+
+  if (check) {
+    await mongo.db.collection('checks').updateOne(check, {
+      $set: {
+        state: 'errored',
+        error: err.message
+      }
+    })
+  }
+}
+
+module.exports = onCheckFailed

--- a/jobs/check/failed.js
+++ b/jobs/check/failed.js
@@ -1,11 +1,17 @@
-const mongo = require('../../lib/utils/mongo')
+const debug = require('debug')('link-proxy:jobs:check')
 
-async function onCheckFailed(linkId, err) {
+const mongo = require('../../lib/utils/mongo')
+const {onError} = require('../../lib/utils/queues')
+
+const {PlungerError} = require('./errors')
+
+async function onCheckFailed(job, err) {
   const check = await mongo.db.collection('checks').findOne({
-    linkId: new mongo.ObjectID(linkId)
+    linkId: new mongo.ObjectID(job.data.linkId)
   }, {
     projection: {
       _id: 1,
+      number: 1,
       options: 1
     },
     sort: {
@@ -14,12 +20,18 @@ async function onCheckFailed(linkId, err) {
   })
 
   if (check) {
-    await mongo.db.collection('checks').updateOne(check, {
+    await mongo.db.collection('checks').updateOne({_id: check._id}, {
       $set: {
         state: 'errored',
         error: err.message
       }
     })
+
+    debug(`Check #${check.number} for link "${job.data.location}" was errored.`)
+  }
+
+  if (!(err instanceof PlungerError)) {
+    onError(job, err)
   }
 }
 

--- a/jobs/check/failed.js
+++ b/jobs/check/failed.js
@@ -30,7 +30,9 @@ async function onCheckFailed(job, err) {
     debug(`Check #${check.number} for link "${job.data.location}" was errored.`)
   }
 
-  if (!(err instanceof PlungerError)) {
+  if (err instanceof PlungerError) {
+    job.remove()
+  } else {
     onError(job, err)
   }
 }

--- a/jobs/check/index.js
+++ b/jobs/check/index.js
@@ -15,6 +15,7 @@ const {updateLink} = require('./link')
 const {getUrlCache, setUrlCache, getFileCache} = require('./cache')
 const {flatten} = require('./flatten')
 const {upload} = require('./upload')
+const {PlungerError} = require('./errors')
 
 const concurrency = cpus().length
 
@@ -66,7 +67,7 @@ async function analyze(linkId, location, options) {
   })
 
   if (tree.error) {
-    throw new Error(tree.error)
+    throw new PlungerError(tree.error)
   }
 
   await mongo.db.collection('checks').updateOne({_id: check._id}, {

--- a/jobs/check/index.js
+++ b/jobs/check/index.js
@@ -65,8 +65,8 @@ async function analyze(linkId, location, options) {
     }
   })
 
-  if (tree.statusCode >= 500) {
-    throw new Error(`Received invalid status code: ${tree.statusCode}`)
+  if (tree.error) {
+    throw new Error(tree.error)
   }
 
   await mongo.db.collection('checks').updateOne({_id: check._id}, {

--- a/jobs/check/index.js
+++ b/jobs/check/index.js
@@ -59,11 +59,15 @@ async function analyze(linkId, location, options) {
     maxDownloadSize: bytes('1GB'),
     concurrency,
     cache: {
-      getFileCache: getFileCache(options.noCache),
-      getUrlCache: getUrlCache(options.noCache),
-      setUrlCache: setUrlCache(options.noCache)
+      getFileCache: getFileCache(check.options.noCache),
+      getUrlCache: getUrlCache(check.options.noCache),
+      setUrlCache: setUrlCache(check.options.noCache)
     }
   })
+
+  if (tree.statusCode >= 500) {
+    throw new Error(`Received invalid status code: ${tree.statusCode}`)
+  }
 
   await mongo.db.collection('checks').updateOne({_id: check._id}, {
     $set: {

--- a/jobs/check/upload.js
+++ b/jobs/check/upload.js
@@ -21,7 +21,7 @@ function formatName(file, ext) {
   return name
 }
 
-function uploadSingle(bundle, distribution) {
+async function uploadSingle(bundle, distribution) {
   const file = bundle.files[0]
 
   const {hostname} = parse(file.url || file.fromUrl)

--- a/lib/utils/queues.js
+++ b/lib/utils/queues.js
@@ -44,8 +44,6 @@ async function init(isSubscriber) {
   }
 
   const checkQueue = new Queue('check', opts)
-  checkQueue.on('failed', onError)
-
   const hooksQueue = new Queue('hooks', opts)
   hooksQueue.on('failed', onError)
 
@@ -78,3 +76,4 @@ async function disconnect() {
 
 exports.init = init
 exports.disconnect = disconnect
+exports.onError = onError

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "micro": "^9.3.2",
     "microrouter": "^3.1.3",
     "mongodb": "^3.1.1",
+    "ms": "^2.1.1",
     "plunger": "^2.3.3",
     "raven": "^2.6.3",
     "unzip-stream": "^0.3.0",
@@ -44,9 +45,12 @@
   "jest": {
     "reporters": [
       "default",
-      ["jest-junit", {
-        "output": "reports/tests/junit.xml"
-      }]
+      [
+        "jest-junit",
+        {
+          "output": "reports/tests/junit.xml"
+        }
+      ]
     ],
     "globalSetup": "./jest.setup.js",
     "globalTeardown": "./jest.teardown.js",

--- a/worker.js
+++ b/worker.js
@@ -3,6 +3,7 @@ const mongo = require('./lib/utils/mongo')
 const queues = require('./lib/utils/queues')
 
 const doCheck = require('./jobs/check')
+const onCheckFailed = require('./jobs/check/failed')
 const doHook = require('./jobs/hooks')
 
 async function main() {
@@ -10,17 +11,10 @@ async function main() {
   await mongo.connect()
   await mongo.ensureIndexes()
 
-  queues.checkQueue.process(({data: {
-    linkId,
-    location,
-    options
-  }}) => doCheck(linkId, location, options))
+  queues.checkQueue.process(({data: {linkId, location, options}}) => doCheck(linkId, location, options))
+  queues.checkQueue.on('failed', ({data: {linkId}}, err) => onCheckFailed(linkId, err))
 
-  queues.hooksQueue.process(({data: {
-    linkId,
-    action,
-    source
-  }}) => doHook(linkId, action, source))
+  queues.hooksQueue.process(({data: {linkId, action, source}}) => doHook(linkId, action, source))
 }
 
 main().catch(err => {

--- a/worker.js
+++ b/worker.js
@@ -12,7 +12,7 @@ async function main() {
   await mongo.ensureIndexes()
 
   queues.checkQueue.process(({data: {linkId, location, options}}) => doCheck(linkId, location, options))
-  queues.checkQueue.on('failed', ({data: {linkId}}, err) => onCheckFailed(linkId, err))
+  queues.checkQueue.on('failed', (job, err) =>  onCheckFailed(job, err))
 
   queues.hooksQueue.process(({data: {linkId, action, source}}) => doHook(linkId, action, source))
 }

--- a/worker.js
+++ b/worker.js
@@ -12,7 +12,7 @@ async function main() {
   await mongo.ensureIndexes()
 
   queues.checkQueue.process(({data: {linkId, location, options}}) => doCheck(linkId, location, options))
-  queues.checkQueue.on('failed', (job, err) =>  onCheckFailed(job, err))
+  queues.checkQueue.on('failed', (job, err) => onCheckFailed(job, err))
 
   queues.hooksQueue.process(({data: {linkId, action, source}}) => doHook(linkId, action, source))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3509,6 +3509,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
 multimatch@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"


### PR DESCRIPTION
Disable cache on the next check in order to make sure we’re not missing
anything on a failed check.

Support plunger errors (tree.error).